### PR TITLE
Override the default semantic-react search function

### DIFF
--- a/src/components/admin_authorities/index.js
+++ b/src/components/admin_authorities/index.js
@@ -156,7 +156,7 @@ class AdminAuthorities extends React.Component {
                     onChange={this.onChange}
                     value={selected}
                     selection
-                    search
+                    search={(options, _) => {return options}}
                     closeOnChange
                     options={options}
                     placeholder="Enter Name"

--- a/src/components/edit-authorities/index.js
+++ b/src/components/edit-authorities/index.js
@@ -157,7 +157,7 @@ class EditAuthorities extends React.Component {
                       onSearchChange={this.onSearchChange}
                       onChange={this.onChange}
                       value={selected}
-                      search
+                      search={(options, _) => {return options}}
                       selection
                       closeOnChange
                       options={options}


### PR DESCRIPTION
Fixes the double searching on yellow_pages search results