### PR TITLE
fix: handle duplicate registration in register_student

### DIFF
--- a/src/components/register_student/index.js
+++ b/src/components/register_student/index.js
@@ -65,6 +65,7 @@ class RegisterStudent extends React.Component {
       fathersContact: '',
       mothersName: '',
       mothersContact: '',
+      isResident: false,
     }
     this.delayedCallback = _.debounce(this.ajaxCall, 300)
   }
@@ -128,7 +129,8 @@ class RegisterStudent extends React.Component {
       fathersName: res.fathersName,
       fathersContact: res.fathersContact,
       mothersName: res.mothersName,
-      mothersContact: res.mothersContact
+      mothersContact: res.mothersContact,
+      isResident: res.isResident,
     })
   }
 
@@ -190,7 +192,8 @@ class RegisterStudent extends React.Component {
       fathersName: '',
       fathersContact: '',
       mothersName: '',
-      mothersContact: ''    
+      mothersContact: '',
+      isResident: false
     })
     toast({
       type: 'success',
@@ -244,6 +247,7 @@ class RegisterStudent extends React.Component {
       fathersContact: '',
       mothersName: '',
       mothersContact: '',
+      isResident: false,
     })
     toast({
       type: 'success',
@@ -324,6 +328,7 @@ class RegisterStudent extends React.Component {
   deregisterSuccessCallBack = (res) => {
     this.setState({
       deregisterLoading: false,
+      isResident: false,
     })
     toast({
       type: 'success',
@@ -348,6 +353,16 @@ class RegisterStudent extends React.Component {
   }
 
   registerStudent = () => {
+    if (this.state.isResident) {
+      toast({
+        type: 'error',
+        title: 'Student is already registered in this bhawan',
+        animation: 'fade up',
+        icon: 'frown outline',
+        time: 4000,
+      })
+      return
+    }
     const {
       selected,
       roomNo,
@@ -463,7 +478,8 @@ class RegisterStudent extends React.Component {
       mothersContact,
       editLoading,
       registerLoading,
-      deregisterLoading
+      deregisterLoading,
+      isResident
     } = this.state
     const { constants } = this.props;
     let feeOptions = [];
@@ -763,6 +779,11 @@ class RegisterStudent extends React.Component {
                   />
                 </Form.Field>
               </Form.Group>
+              {isResident && (
+                <div className='ui negative message'>
+                  Already registered
+                </div>
+              )}
               <div>
               <Button
                   primary
@@ -778,7 +799,7 @@ class RegisterStudent extends React.Component {
                   type='submit'
                   loading={registerLoading}
                   onClick={this.registerStudent}
-                  disabled={!roomNo || !selected || !feeStatus}
+                  disabled={!roomNo || !selected || !feeStatus || isResident}
                 >
                   Register
                 </Button>


### PR DESCRIPTION
This pull request enhances the `RegisterStudent` component by introducing logic to prevent students who are already residents from being registered again. It adds a new `isResident` state property, updates the UI to show a warning if a student is already registered, and disables the registration button in such cases.

**Resident status handling:**

* Added a new `isResident` property to the component state and ensured it is properly initialized, reset, and updated throughout the registration and deregistration flows. [[1]](diffhunk://#diff-5c39e909a88e8802d0a3c0b2ddd5702122957a523492fcd086f0853b94f2b0a1R68) [[2]](diffhunk://#diff-5c39e909a88e8802d0a3c0b2ddd5702122957a523492fcd086f0853b94f2b0a1L131-R133) [[3]](diffhunk://#diff-5c39e909a88e8802d0a3c0b2ddd5702122957a523492fcd086f0853b94f2b0a1L193-R196) [[4]](diffhunk://#diff-5c39e909a88e8802d0a3c0b2ddd5702122957a523492fcd086f0853b94f2b0a1R250) [[5]](diffhunk://#diff-5c39e909a88e8802d0a3c0b2ddd5702122957a523492fcd086f0853b94f2b0a1R331) [[6]](diffhunk://#diff-5c39e909a88e8802d0a3c0b2ddd5702122957a523492fcd086f0853b94f2b0a1L466-R482)

**UI/UX improvements:**

* Added a check in the `registerStudent` method to prevent registration if the student is already a resident, displaying an error toast notification in this case.
* Displayed a negative message in the form if the student is already registered, providing clear feedback to the user.
* Disabled the "Register" button when the student is already a resident to prevent duplicate registrations.
<img width="684" height="924" alt="Screenshot From 2026-04-06 16-08-39" src="https://github.com/user-attachments/assets/5388a788-67dc-407b-88e9-2440f9a38ec8" />
