### PR TITLE
Fix duplicate registration handling and add folder for non-residents

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -25,6 +25,7 @@ const EditAuthorities = lazy(() => import("./edit-authorities/index"))
 const AddFacility = lazy(() => import("./add-facility/index"))
 const RegisterStudent = lazy(() => import("./register_student/index"))
 const Rooms = lazy(() => import("./rooms/index"))
+const NonResidingStudents = lazy(() => import("./non_residing_students/index"))
 
 import { whoami } from "../actions/who_am_i";
 import { getConstants } from "../actions/get-constants";
@@ -315,6 +316,12 @@ class App extends React.Component {
                       <AdminRoute
                         path={`${match.path}registration`}
                         component={RegisterStudent}
+                        setNavigation={this.setNavigation}
+                        {...this.props}
+                      />
+                      <AdminRoute
+                        path={`${match.path}non_residing_students`}
+                        component={NonResidingStudents}
                         setNavigation={this.setNavigation}
                         {...this.props}
                       />

--- a/src/components/navbar/index.js
+++ b/src/components/navbar/index.js
@@ -25,7 +25,8 @@ import {
   complaintUrl,
   registrationUrl,
   databaseUrl,
-  roomUrl
+  roomUrl,
+  nonResidingStudentsPageUrl,
 } from '../../urls'
 
 const hamburgerDefaultOptions = [
@@ -105,6 +106,12 @@ class Nav extends Component {
       case roomUrl(): {
         this.setState({
           activeSubGroup: 'rooms'
+        })
+        return
+      }
+      case nonResidingStudentsPageUrl(): {
+        this.setState({
+          activeSubGroup: 'non-residing-students'
         })
         return
       }
@@ -316,6 +323,17 @@ class Nav extends Component {
               onClick={() => this.handleGroupClick('room', '/bhawan_app/room')}
             >
               Accommodation
+            </Menu.Item>
+
+            <Menu.Item
+              size='mini'
+              name='non-residing-students'
+              color='blue'
+              styleName='navCss.navColor'
+              active={activeSubGroup == 'non-residing-students'}
+              onClick={() => this.handleGroupClick('non-residing-students', '/bhawan_app/non_residing_students')}
+            >
+              Non Residing Students
             </Menu.Item>
           </Menu>
         ) : (

--- a/src/components/non_residing_students/index.css
+++ b/src/components/non_residing_students/index.css
@@ -1,0 +1,37 @@
+/* NRS header action buttons: better contrast and clearer selected interaction state */
+.ui.grid > .row > .right.aligned.eight.wide.column > .ui.button {
+	margin-left: 0.45rem !important;
+	border-radius: 8px !important;
+	border: 1px solid #d6d9e0 !important;
+	background: #f4f6f9 !important;
+	color: #1f2937 !important;
+	font-weight: 600 !important;
+	transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.ui.grid > .row > .right.aligned.eight.wide.column > .ui.button:hover {
+	background: #e7ebf2 !important;
+	border-color: #c8d0de !important;
+}
+
+.ui.grid > .row > .right.aligned.eight.wide.column > .ui.button:active,
+.ui.grid > .row > .right.aligned.eight.wide.column > .ui.button:focus,
+.ui.grid > .row > .right.aligned.eight.wide.column > .ui.button:focus-visible {
+	background: #324a6d !important;
+	border-color: #243754 !important;
+	color: #ffffff !important;
+	box-shadow: 0 0 0 2px rgba(50, 74, 109, 0.2) !important;
+}
+
+.ui.grid > .row > .right.aligned.eight.wide.column > .ui.primary.button,
+.ui.grid > .row > .right.aligned.eight.wide.column > .ui.secondary.button {
+	background: #2e4a7d !important;
+	border-color: #233a62 !important;
+	color: #ffffff !important;
+}
+
+.ui.grid > .row > .right.aligned.eight.wide.column > .ui.primary.button:hover,
+.ui.grid > .row > .right.aligned.eight.wide.column > .ui.secondary.button:hover {
+	background: #233a62 !important;
+	border-color: #1a2d4d !important;
+}

--- a/src/components/non_residing_students/index.js
+++ b/src/components/non_residing_students/index.js
@@ -1,0 +1,645 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import { toast } from 'react-semantic-toasts'
+import moment from 'moment'
+import axios from 'axios'
+import { getCookie } from 'formula_one/src/utils'
+
+import {
+  Button,
+  Container,
+  Dropdown,
+  Form,
+  Header,
+  Input,
+  Segment,
+  Table,
+  Grid,
+} from 'semantic-ui-react'
+
+import {
+  nonResidingStudentsUrl,
+  allNonResidingStudentsUrl,
+} from '../../urls'
+import './index.css'
+
+
+class NonResidingStudents extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      name: '',
+      designation: '',
+      department: '',
+      mobileNumber: '',
+      roomNumber: '',
+      fromDate: '',
+      uptoDate: '',
+      emailId: '',
+      saving: false,
+      loading: true,
+      students: [],
+      showAddForm: false,
+      editMode: false,
+      editingStudentId: null,
+      searchQuery: '',
+      filterDesignation: '',
+      filterDepartment: '',
+      filterBhawan: '',
+      showAllBhawans: false,
+    }
+  }
+
+  componentDidMount () {
+    if (this.props.setNavigation) {
+      this.props.setNavigation('Non Residing Students')
+    }
+    this.fetchStudents()
+  }
+
+  componentDidUpdate (prevProps) {
+    if (prevProps.activeHostel !== this.props.activeHostel) {
+      this.fetchStudents()
+    }
+  }
+
+  fetchStudents = () => {
+    this.setState({ loading: true })
+    axios
+      .get(nonResidingStudentsUrl(this.props.activeHostel))
+      .then((res) => {
+        this.setState({
+          students: res.data,
+          loading: false,
+        })
+      })
+      .catch(() => {
+        this.setState({
+          students: [],
+          loading: false,
+        })
+      })
+  }
+
+  fetchAllStudents = () => {
+    this.setState({ loading: true })
+    axios
+      .get(allNonResidingStudentsUrl())
+      .then((res) => {
+        this.setState({
+          students: res.data,
+          loading: false,
+          showAllBhawans: true,
+        })
+      })
+      .catch(() => {
+        this.setState({ loading: false })
+        toast({
+          type: 'error',
+          title: 'You are not allowed to view all bhawans',
+          animation: 'fade up',
+          icon: 'frown outline',
+          time: 3000,
+        })
+      })
+  }
+
+  showCurrentBhawanStudents = () => {
+    this.setState({
+      showAllBhawans: false,
+      filterBhawan: '',
+    })
+    this.fetchStudents()
+  }
+
+  downloadFilteredCsv = (filteredStudents) => {
+    const { filterDesignation, filterDepartment, filterBhawan, showAllBhawans, searchQuery } = this.state
+    const { constants, activeHostel } = this.props
+
+    const currentBhawanName = constants.hostels && constants.hostels[activeHostel] ? constants.hostels[activeHostel] : activeHostel
+    const filteredOn = [
+      `Scope=${showAllBhawans ? 'All Bhawans' : currentBhawanName}`,
+      `Search=${searchQuery || 'NA'}`,
+      `Designation=${filterDesignation || 'NA'}`,
+      `Department=${this.getDepartmentLabel(filterDepartment) || 'NA'}`,
+      `Bhawan=${filterBhawan || 'NA'}`,
+    ].join('; ')
+
+    const rows = filteredStudents.map((student) => {
+      const mobile = student.mobile_number || student.mobileNumber || ''
+      const room = student.room_number || student.roomNumber || ''
+      const fromDate = student.from_date || student.fromDate || ''
+      const uptoDate = student.upto_date || student.uptoDate || ''
+      const email = student.email_id || student.emailId || ''
+      const bhawanCode = student.hostel_code || student.hostelCode || ''
+      const bhawanName = student.hostel_name || student.hostelName || (constants.hostels && constants.hostels[bhawanCode]) || (constants.hostels && constants.hostels[activeHostel]) || ''
+      return [
+        bhawanName,
+        student.name || '',
+        student.designation || '',
+        this.getDepartmentLabel(student.department || ''),
+        mobile,
+        room,
+        fromDate ? moment(fromDate).format('DD/MM/YYYY') : '',
+        uptoDate ? moment(uptoDate).format('DD/MM/YYYY') : '',
+        email,
+      ]
+    })
+
+    const csvLines = [
+      `Filtered on:,${filteredOn}`,
+      'Name of the bhawan,Name,Designation,Department,Mobile number,Room number,From (date),Upto (date),Email-id',
+      ...rows.map((row) => row.map((col) => `"${String(col).replace(/"/g, '""')}"`).join(',')),
+    ]
+
+    const blob = new Blob([csvLines.join('\n')], { type: 'text/csv;charset=utf-8;' })
+    const url = window.URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = url
+    link.setAttribute('download', 'non_residing_students_filtered.csv')
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+    window.URL.revokeObjectURL(url)
+  }
+
+  handleChange = (e, { name, value }) => {
+    this.setState({ [name]: value })
+  }
+
+  getDepartmentCodeFromValue = (value) => {
+    const { constants } = this.props
+    if (!value) {
+      return ''
+    }
+
+    if (constants.departments && constants.departments[value]) {
+      return value
+    }
+
+    if (constants.departments) {
+      for (const code in constants.departments) {
+        if (constants.departments[code] === value) {
+          return code
+        }
+      }
+    }
+
+    return value
+  }
+
+  getDepartmentLabel = (value) => {
+    const { constants } = this.props
+    if (!value) {
+      return ''
+    }
+    return (constants.departments && constants.departments[value]) || value
+  }
+
+  toggleAddForm = () => {
+    this.setState((prevState) => ({
+      showAddForm: !prevState.showAddForm,
+      editMode: prevState.showAddForm ? false : prevState.editMode,
+      editingStudentId: prevState.showAddForm ? null : prevState.editingStudentId,
+    }))
+  }
+
+  editStudent = (student) => {
+    this.setState({
+      showAddForm: true,
+      editMode: true,
+      editingStudentId: student.id,
+      name: student.name || '',
+      designation: student.designation || '',
+      department: this.getDepartmentCodeFromValue(student.department || ''),
+      mobileNumber: student.mobile_number || student.mobileNumber || '',
+      roomNumber: student.room_number || student.roomNumber || '',
+      fromDate: student.from_date || student.fromDate || '',
+      uptoDate: student.upto_date || student.uptoDate || '',
+      emailId: student.email_id || student.emailId || '',
+    })
+  }
+
+  resetForm = () => {
+    this.setState({
+      name: '',
+      designation: '',
+      department: '',
+      mobileNumber: '',
+      roomNumber: '',
+      fromDate: '',
+      uptoDate: '',
+      emailId: '',
+      saving: false,
+      editMode: false,
+      editingStudentId: null,
+    })
+  }
+
+  handleSubmit = () => {
+    const {
+      name,
+      designation,
+      department,
+      mobileNumber,
+      roomNumber,
+      fromDate,
+      uptoDate,
+      emailId,
+      editMode,
+      editingStudentId,
+    } = this.state
+
+    const parsedFromDate = moment(fromDate, 'YYYY-MM-DD', true)
+    const parsedUptoDate = moment(uptoDate, 'YYYY-MM-DD', true)
+
+    if (!parsedFromDate.isValid() || !parsedUptoDate.isValid()) {
+      toast({
+        type: 'error',
+        title: 'Please enter valid dates',
+        animation: 'fade up',
+        icon: 'frown outline',
+        time: 3000,
+      })
+      return
+    }
+
+    if (!parsedFromDate.isBefore(parsedUptoDate)) {
+      toast({
+        type: 'error',
+        title: 'From date must be earlier than Upto date',
+        animation: 'fade up',
+        icon: 'frown outline',
+        time: 3000,
+      })
+      return
+    }
+
+    const payload = {
+      name: name,
+      designation: designation,
+      department: department || '',
+      mobile_number: mobileNumber,
+      room_number: roomNumber,
+      from_date: fromDate,
+      upto_date: uptoDate,
+      email_id: emailId,
+    }
+
+    this.setState({ saving: true })
+    const headers = {
+      'Content-Type': 'application/json',
+      'X-CSRFToken': getCookie('csrftoken'),
+    }
+    axios
+      [editMode ? 'patch' : 'post'](
+        editMode
+          ? `${nonResidingStudentsUrl(this.props.activeHostel)}${editingStudentId}/`
+          : nonResidingStudentsUrl(this.props.activeHostel),
+        payload,
+        { headers: headers }
+      )
+      .then(() => {
+        this.resetForm()
+        this.fetchStudents()
+        toast({
+          type: 'success',
+          title: editMode ? 'Non residing student updated successfully' : 'Non residing student registered successfully',
+          animation: 'fade up',
+          icon: 'smile outline',
+          time: 3000,
+        })
+      })
+      .catch(() => {
+        this.setState({ saving: false })
+        toast({
+          type: 'error',
+          title: 'Unable to register non residing student',
+          animation: 'fade up',
+          icon: 'frown outline',
+          time: 3000,
+        })
+      })
+  }
+
+  render () {
+    const {
+      name,
+      designation,
+      department,
+      mobileNumber,
+      roomNumber,
+      fromDate,
+      uptoDate,
+      emailId,
+      saving,
+      loading,
+      students,
+      showAddForm,
+      editMode,
+      searchQuery,
+      filterDesignation,
+      filterDepartment,
+      filterBhawan,
+      showAllBhawans,
+    } = this.state
+
+    const { constants, activeHostel } = this.props
+
+    const designationOptions = [
+      { key: 'ra', text: 'RA', value: 'ra' },
+      { key: 'pdf', text: 'PDF', value: 'pdf' },
+      { key: 'jrf', text: 'JRF', value: 'jrf' },
+      { key: 'srf', text: 'SRF', value: 'srf' },
+      { key: 'project_fellow', text: 'Project Fellow', value: 'project_fellow' },
+      { key: 'npdf', text: 'NPDF', value: 'npdf' },
+      { key: 'ipdf', text: 'IPDF', value: 'ipdf' },
+      { key: 'research_intern', text: 'Research Intern', value: 'research_intern' },
+      { key: 'visitor', text: 'Visitor', value: 'visitor' },
+    ]
+
+    let departmentOptions = []
+    if (constants.departments) {
+      for (const code in constants.departments) {
+        departmentOptions = [
+          ...departmentOptions,
+          {
+            key: code,
+            text: constants.departments[code],
+            value: code,
+          },
+        ]
+      }
+    }
+
+    const filteredStudents = students.filter((student) => {
+      const mobile = student.mobile_number || student.mobileNumber || ''
+      const email = student.email_id || student.emailId || ''
+      const room = student.room_number || student.roomNumber || ''
+      const deptValue = student.department || ''
+      const deptLabel = this.getDepartmentLabel(deptValue)
+      const bhawanCode = (student.hostel_code || student.hostelCode || '').toLowerCase()
+      const query = searchQuery.trim().toLowerCase()
+      const designationMatch = !filterDesignation || student.designation === filterDesignation
+      const departmentMatch = !filterDepartment || deptValue === filterDepartment || deptLabel === filterDepartment
+      const bhawanMatch = !filterBhawan || bhawanCode === filterBhawan.toLowerCase()
+      if (!designationMatch || !departmentMatch || !bhawanMatch) {
+        return false
+      }
+      if (!query) {
+        return true
+      }
+      return (
+        (student.name || '').toLowerCase().includes(query) ||
+        mobile.toLowerCase().includes(query) ||
+        email.toLowerCase().includes(query) ||
+        room.toLowerCase().includes(query) ||
+        deptValue.toLowerCase().includes(query) ||
+        deptLabel.toLowerCase().includes(query)
+      )
+    })
+
+    return (
+      <Container>
+        <Grid>
+          <Grid.Row verticalAlign='middle'>
+            <Grid.Column width={8}>
+              <Header as='h3'>Non Residing Students</Header>
+            </Grid.Column>
+            <Grid.Column width={8} textAlign='right'>
+              <Button primary type='button' onClick={this.toggleAddForm}>
+                {showAddForm ? 'Close Form' : 'Add Non Dining Student'}
+              </Button>
+              <Button type='button' onClick={this.fetchAllStudents}>Show All Bhawans</Button>
+              <Button  type='button' onClick={this.showCurrentBhawanStudents}>Show Current Bhawan</Button>
+            </Grid.Column>
+          </Grid.Row>
+     
+        
+        </Grid>
+
+        {showAddForm && (
+          <Segment>
+            <Form>
+              <Form.Field required>
+                <label>Name of the bhawan</label>
+                <Input
+                  value={constants.hostels && constants.hostels[activeHostel]}
+                  readOnly
+                  disabled
+                />
+              </Form.Field>
+              <Form.Field required>
+                <label>Name</label>
+                <Input name='name' value={name} onChange={this.handleChange} />
+              </Form.Field>
+              <Form.Field required>
+                <label>Designation (RA/PDF/JRF/SRF/Project Fellow/NPDF/IPDF/Research Intern/Visitor)</label>
+                <Dropdown
+                  name='designation'
+                  selection
+                  options={designationOptions}
+                  value={designation}
+                  onChange={this.handleChange}
+                />
+              </Form.Field>
+              <Form.Field>
+                <label>Department</label>
+                <Dropdown
+                  name='department'
+                  selection
+                  search
+                  clearable
+                  options={departmentOptions}
+                  value={department}
+                  onChange={this.handleChange}
+                  placeholder='Select department (optional)'
+                />
+              </Form.Field>
+              <Form.Field required>
+                <label>Mobile number</label>
+                <Input name='mobileNumber' value={mobileNumber} onChange={this.handleChange} />
+              </Form.Field>
+              <Form.Field required>
+                <label>Room number</label>
+                <Input name='roomNumber' value={roomNumber} onChange={this.handleChange} />
+              </Form.Field>
+              <Form.Field required>
+                <label>From (date)</label>
+                <Input type='date' name='fromDate' value={fromDate} onChange={this.handleChange} />
+              </Form.Field>
+              <Form.Field required>
+                <label>Upto (date)</label>
+                <Input type='date' name='uptoDate' value={uptoDate} onChange={this.handleChange} />
+              </Form.Field>
+              <Form.Field required>
+                <label>Email-id</label>
+                <Input type='email' name='emailId' value={emailId} onChange={this.handleChange} />
+              </Form.Field>
+
+              <Button
+                primary
+                type='button'
+                onClick={this.handleSubmit}
+                loading={saving}
+                disabled={
+                  !name ||
+                  !designation ||
+                  !mobileNumber ||
+                  !roomNumber ||
+                  !fromDate ||
+                  !uptoDate ||
+                  !emailId
+                }
+              >
+                {editMode ? 'Update Non Dining Student' : 'Save Non Dining Student'}
+              </Button>
+              {editMode && (
+                <Button
+                  type='button'
+                  onClick={() => {
+                    this.resetForm()
+                    this.setState({ showAddForm: false })
+                  }}
+                >
+                  Cancel Edit
+                </Button>
+              )}
+            </Form>
+          </Segment>
+        )}
+
+        <Segment>
+          <Grid>
+            <Grid.Row>
+              <Grid.Column width={6}>
+                <Input
+                  fluid
+                  icon='search'
+                  placeholder='Search by name/mobile/email/room/department'
+                  name='searchQuery'
+                  value={searchQuery}
+                  onChange={this.handleChange}
+                />
+              </Grid.Column>
+              <Grid.Column width={5}>
+                <Dropdown
+                  fluid
+                  selection
+                  clearable
+                  placeholder='Filter by designation'
+                  name='filterDesignation'
+                  value={filterDesignation}
+                  options={designationOptions}
+                  onChange={this.handleChange}
+                />
+              </Grid.Column>
+              <Grid.Column width={5}>
+                <Dropdown
+                  fluid
+                  selection
+                  search
+                  clearable
+                  placeholder='Filter by department'
+                  name='filterDepartment'
+                  value={filterDepartment}
+                  options={departmentOptions}
+                  onChange={this.handleChange}
+                />
+              </Grid.Column>
+              <Grid.Column width={5}>
+                <Dropdown
+                  fluid
+                  selection
+                  search
+                  clearable
+                  placeholder='Filter by bhawan'
+                  name='filterBhawan'
+                  value={filterBhawan}
+
+                  options={Object.keys(constants.hostels || {}).map((code) => ({ key: code, text: constants.hostels[code], value: code }))}
+                  onChange={this.handleChange}
+                />
+              </Grid.Column>
+            </Grid.Row>
+          </Grid>
+        </Segment>
+
+        <Segment>
+          <div>Total Count: {filteredStudents.length}</div>
+        <Button style={{ marginBottom: '5px' }}  type='button' onClick={() => this.downloadFilteredCsv(filteredStudents)}>Download  CSV</Button>
+
+          <div style={{ overflowX: 'auto' }}>
+          <Table celled compact unstackable>
+            <Table.Header>
+              <Table.Row>
+                <Table.HeaderCell>Name of the bhawan</Table.HeaderCell>
+                <Table.HeaderCell>Name</Table.HeaderCell>
+                <Table.HeaderCell>Designation</Table.HeaderCell>
+                <Table.HeaderCell>Department</Table.HeaderCell>
+                <Table.HeaderCell>Mobile number</Table.HeaderCell>
+                <Table.HeaderCell>Room number</Table.HeaderCell>
+                <Table.HeaderCell>From (date)</Table.HeaderCell>
+                <Table.HeaderCell>Upto (date)</Table.HeaderCell>
+                <Table.HeaderCell>Email-id</Table.HeaderCell>
+                <Table.HeaderCell>Edit</Table.HeaderCell>
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {!loading && filteredStudents.length > 0 ? (
+                filteredStudents.map((student) => {
+                  const designationObj = designationOptions.find((item) => item.value === student.designation) || {}
+                  const mobile = student.mobile_number || student.mobileNumber || ''
+                  const room = student.room_number || student.roomNumber || ''
+                  const fromDate = student.from_date || student.fromDate || ''
+                  const uptoDate = student.upto_date || student.uptoDate || ''
+                  const email = student.email_id || student.emailId || ''
+                  const bhawanCode = student.hostel_code || student.hostelCode || ''
+                  const bhawanName = student.hostel_name || student.hostelName || (constants.hostels && constants.hostels[bhawanCode]) || (constants.hostels && constants.hostels[activeHostel]) || ''
+                  return (
+                    
+                    <Table.Row key={student.id}>
+                      <Table.Cell>{bhawanName}</Table.Cell>
+                      <Table.Cell>{student.name}</Table.Cell>
+                      <Table.Cell>{designationObj.text || student.designation}</Table.Cell>
+                      <Table.Cell>{this.getDepartmentLabel(student.department)}</Table.Cell>
+                      <Table.Cell>{mobile}</Table.Cell>
+                      <Table.Cell>{room}</Table.Cell>
+                      <Table.Cell>{fromDate ? moment(fromDate).format('DD/MM/YYYY') : ''}</Table.Cell>
+                      <Table.Cell>{uptoDate ? moment(uptoDate).format('DD/MM/YYYY') : ''}</Table.Cell>
+                      <Table.Cell>{email}</Table.Cell>
+                      <Table.Cell>
+                        <Button size='small' onClick={() => this.editStudent(student)}>
+                          Edit
+                        </Button>
+                      </Table.Cell>
+                    </Table.Row>
+                  )
+                })
+              ) : loading ? (
+                <Table.Row>
+                  <Table.Cell colSpan='10'>Loading...</Table.Cell>
+                </Table.Row>
+              ) : (
+                <Table.Row>
+                  <Table.Cell colSpan='10'>No records found.</Table.Cell>
+                </Table.Row>
+              )}
+            </Table.Body>
+          </Table>
+          </div>
+        </Segment>
+      </Container>
+    )
+  }
+}
+
+
+function mapStateToProps (state) {
+  return {
+    activeHostel: state.activeHostel,
+  }
+}
+
+
+export default connect(mapStateToProps, null)(NonResidingStudents)

--- a/src/components/register_student/index.js
+++ b/src/components/register_student/index.js
@@ -65,6 +65,7 @@ class RegisterStudent extends React.Component {
       fathersContact: '',
       mothersName: '',
       mothersContact: '',
+      isResident: false,
     }
     this.delayedCallback = _.debounce(this.ajaxCall, 300)
   }
@@ -128,7 +129,8 @@ class RegisterStudent extends React.Component {
       fathersName: res.fathersName,
       fathersContact: res.fathersContact,
       mothersName: res.mothersName,
-      mothersContact: res.mothersContact
+      mothersContact: res.mothersContact,
+      isResident: res.isResident,
     })
   }
 
@@ -190,7 +192,8 @@ class RegisterStudent extends React.Component {
       fathersName: '',
       fathersContact: '',
       mothersName: '',
-      mothersContact: ''    
+      mothersContact: '',
+      isResident: false
     })
     toast({
       type: 'success',
@@ -244,6 +247,7 @@ class RegisterStudent extends React.Component {
       fathersContact: '',
       mothersName: '',
       mothersContact: '',
+      isResident: false,
     })
     toast({
       type: 'success',
@@ -324,6 +328,7 @@ class RegisterStudent extends React.Component {
   deregisterSuccessCallBack = (res) => {
     this.setState({
       deregisterLoading: false,
+      isResident: false,
     })
     toast({
       type: 'success',
@@ -348,6 +353,16 @@ class RegisterStudent extends React.Component {
   }
 
   registerStudent = () => {
+    if (this.state.isResident) {
+      toast({
+        type: 'error',
+        title: 'Student is already registered in this bhawan',
+        animation: 'fade up',
+        icon: 'frown outline',
+        time: 4000,
+      })
+      return
+    }
     const {
       selected,
       roomNo,
@@ -463,7 +478,8 @@ class RegisterStudent extends React.Component {
       mothersContact,
       editLoading,
       registerLoading,
-      deregisterLoading
+      deregisterLoading,
+      isResident
     } = this.state
     const { constants } = this.props;
     let feeOptions = [];
@@ -763,6 +779,11 @@ class RegisterStudent extends React.Component {
                   />
                 </Form.Field>
               </Form.Group>
+              {isResident && (
+                <div className='ui negative message'>
+                  Already registered
+                </div>
+              )}
               <div>
               <Button
                   primary
@@ -778,7 +799,7 @@ class RegisterStudent extends React.Component {
                   type='submit'
                   loading={registerLoading}
                   onClick={this.registerStudent}
-                  disabled={!roomNo || !selected || !feeStatus}
+                  disabled={!roomNo || !selected || !feeStatus || isResident}
                 >
                   Register
                 </Button>

--- a/src/components/register_student/index.js
+++ b/src/components/register_student/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { connect } from 'react-redux'
 import { toast } from 'react-semantic-toasts'
 import moment from 'moment'
+import debounce from 'lodash/debounce'
 
 import {
   Button,
@@ -67,7 +68,13 @@ class RegisterStudent extends React.Component {
       mothersContact: '',
       isResident: false,
     }
-    this.delayedCallback = _.debounce(this.ajaxCall, 300)
+    this.delayedCallback = debounce(this.ajaxCall, 300)
+  }
+
+  componentDidMount () {
+    if (this.props.setNavigation) {
+      this.props.setNavigation('Registration')
+    }
   }
 
   successCallBack = (res) => {

--- a/src/urls.js
+++ b/src/urls.js
@@ -53,6 +53,10 @@ export const databaseUrl = () => {
   return `${baseNavUrl('/database')}`
 }
 
+export const nonResidingStudentsPageUrl = () => {
+  return `${baseNavUrl('/non_residing_students')}`
+}
+
 // Backend URLs
 
 export const baseApiUrl = () => {
@@ -195,4 +199,16 @@ export const markInsideUrl = (residence, person) => {
 
 export const markOutUrl = (residence, person) => {
   return `${baseApiUrl()}${residence}/resident/${person}/markout/`
+}
+
+export const nonResidingStudentsUrl = (residence) => {
+  return `${baseApiUrl()}${residence}/non_residing_student/`
+}
+
+export const nonResidingStudentsDownloadUrl = (residence) => {
+  return `${baseApiUrl()}${residence}/non_residing_student/download/`
+}
+
+export const allNonResidingStudentsUrl = () => {
+  return `${baseApiUrl()}non_residing_student/all/`
 }


### PR DESCRIPTION

https://github.com/user-attachments/assets/7536d0f2-a042-4fea-9501-d91f804e326f

This pull request introduces a new "Non Residing Students" (NRS) feature to the application, including a dedicated page, navigation updates, backend URL endpoints, and related UI enhancements. It also improves the student registration workflow by handling resident status and preventing duplicate registrations.

**Non Residing Students Feature:**

* Added a new lazy-loaded `NonResidingStudents` component and corresponding admin route in `app.js`, enabling access to the NRS page. [[1]](diffhunk://#diff-da6e9a947e611ea86124f52d4ea0ec503133f2fc53edd0d47650a0e5e037d15dR28) [[2]](diffhunk://#diff-da6e9a947e611ea86124f52d4ea0ec503133f2fc53edd0d47650a0e5e037d15dR322-R327)
* Introduced NRS-specific navigation: updated the navbar to include a "Non Residing Students" menu item, managed its active state, and added the page URL to the navigation URLs. [[1]](diffhunk://#diff-21324f5fcda0b984f6d3242e177b10892b147ad3b66e2e6605972e8b4295da8bL28-R29) [[2]](diffhunk://#diff-21324f5fcda0b984f6d3242e177b10892b147ad3b66e2e6605972e8b4295da8bR112-R117) [[3]](diffhunk://#diff-21324f5fcda0b984f6d3242e177b10892b147ad3b66e2e6605972e8b4295da8bR327-R337) [[4]](diffhunk://#diff-2932fede0df6397a761e403be6b2eabe8e4ead587d29bffa170adbe4dc235a21R56-R59)
* Added new backend API endpoints for fetching, downloading, and listing non-residing students in `urls.js`.

**UI/UX Enhancements:**

* Created a dedicated CSS file for the NRS component, improving the appearance and interaction states of header action buttons.

**Student Registration Improvements:**

* Enhanced the registration form in `register_student/index.js` to track and display the resident status (`isResident`) of a student, preventing duplicate registrations and providing user feedback when attempting to register an already-registered student. [[1]](diffhunk://#diff-5c39e909a88e8802d0a3c0b2ddd5702122957a523492fcd086f0853b94f2b0a1R5) [[2]](diffhunk://#diff-5c39e909a88e8802d0a3c0b2ddd5702122957a523492fcd086f0853b94f2b0a1R69-L69) [[3]](diffhunk://#diff-5c39e909a88e8802d0a3c0b2ddd5702122957a523492fcd086f0853b94f2b0a1L131-R140) [[4]](diffhunk://#diff-5c39e909a88e8802d0a3c0b2ddd5702122957a523492fcd086f0853b94f2b0a1L193-R203) [[5]](diffhunk://#diff-5c39e909a88e8802d0a3c0b2ddd5702122957a523492fcd086f0853b94f2b0a1R257) [[6]](diffhunk://#diff-5c39e909a88e8802d0a3c0b2ddd5702122957a523492fcd086f0853b94f2b0a1R338) [[7]](diffhunk://#diff-5c39e909a88e8802d0a3c0b2ddd5702122957a523492fcd086f0853b94f2b0a1R363-R372) [[8]](diffhunk://#diff-5c39e909a88e8802d0a3c0b2ddd5702122957a523492fcd086f0853b94f2b0a1L466-R489) [[9]](diffhunk://#diff-5c39e909a88e8802d0a3c0b2ddd5702122957a523492fcd086f0853b94f2b0a1R789-R793) [[10]](diffhunk://#diff-5c39e909a88e8802d0a3c0b2ddd5702122957a523492fcd086f0853b94f2b0a1L781-R809)